### PR TITLE
Added optional "handled_locales" setting

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -6,13 +6,12 @@ Accept-languages header parser middleware
 
     var i18n = require('connect-i18n');
     app.use(i18n({default_locale: 'es-es'}));
+    // or, with a "handled locales" Array:
+    app.use(i18n({default_locale: 'es-es', handled_locales: ['es', 'fr', 'en']}));
 
     console.log(req.locales);
 
 ## options
 
 * default_locale: Sets your default locale
-
-## test
-
-    make
+* handled_locales: If set, only locales defined by the user browser and found in this Array will be present in `req.locales`

--- a/lib/connect-i18n.js
+++ b/lib/connect-i18n.js
@@ -1,5 +1,3 @@
-var queryString = require('querystring');
-
 /**
  * Parse from Accept-language header
  *
@@ -17,16 +15,28 @@ module.exports = function (options) {
 
   return function i18n(req, res, next) {
     var accept_language = req.headers['accept-language'],
-        tokens = [],
-        locales = [];
+      locales = [];
 
     if (accept_language) {
       accept_language.split(',').forEach(function (lang) {
         locales.push(lang.split(';', 1)[0].toLowerCase());
       });
 
+      // We may have an array of "handled locales" (i.e. ['en', 'fr'])
+      if (options.handled_locales) {
+        var filteredLocales = [];
+        locales.forEach(function (locale) {
+          if (options.handled_locales.indexOf(locale) > -1) {
+            filteredLocales.push(locale);
+          }
+        });
+        locales = filteredLocales;
+      }
+
       req.locales = locales;
-    } else {
+    }
+
+    if ((!req.locales || req.locales.length === 0) && options.default_locale) {
       req.locales = [options.default_locale];
     }
 

--- a/package.json
+++ b/package.json
@@ -4,9 +4,6 @@
   "version": "0.2.0",
   "author": "Pau Ramon <masylum@gmail.com>",
   "main": "./lib/connect-i18n",
-  "devDependencies": {
-    "testosterone": ">= 1.2.0"
-  },
   "engines": { "node": ">= 0.4.0" }
 }
 


### PR DESCRIPTION
- Added optional "handled_locales" setting
- removed unused test stuff
- removed useless "tokens" variable
- if we have no "accept-language" HTTP header, the default locale will be set as "req.locales"
